### PR TITLE
fix decoding issue

### DIFF
--- a/unbxdSearch.js
+++ b/unbxdSearch.js
@@ -561,7 +561,7 @@ var unbxdSearchInit = function(jQuery, Handlebars){
               ,decodedParamscount = Object.keys(decodedParams).length
               ,finalParams = null;
 
-	      if(decodedParamscount > 0){
+	      if(!this.options.noEncoding && decodedParamscount > 0){
                 finalParams = this._processURL(decodedParams);
 	      }else{
                 finalParams = this._processURL(urlqueryparams);


### PR DESCRIPTION
This was happening since it was decoding the url even if its not encoded
at all. It will return empty object sometimes, but sometimes it will
return object with some random unicode characters as key value pairs.

Add if condition to check if the url is encoded or not. If it is
encoded then only decode it.

@rahulcs 