### PR TITLE
Fixed issue that comes if a facet value ends with a double quote

### DIFF
--- a/unbxdSearch.js
+++ b/unbxdSearch.js
@@ -1265,7 +1265,7 @@ var unbxdSearchInit = function(jQuery, Handlebars){
 	  for(var x = 0; x < filterStrArr.length; x++){
 	    var arr = filterStrArr[x].split(":");
 	    if(arr.length == 2){
-	      arr[1] = arr[1].replace(/\"{2,}/g, '"').replace(/(^")|("$)/g, '').replace(/(^\[)|(\]$)/g, '');
+	      arr[1] = arr[1].replace(/(^")|("$)/g, '').replace(/\"{2,}/g, '"').replace(/(^\[)|(\]$)/g, '');
 
 	      var vals = arr[1].split(" TO ");
 	      if(vals.length > 1){


### PR DESCRIPTION
@santosh1994 @rahulcs Please review.

**Problem :** If a facet value ends with a double quote and you apply the facet and reload the newly formed url, the library removes the ending quote and creates a malformed search api request.

**Explanation :** 
If I have a facet value **25.0"**, its filtered url component becomes **Height_fq:"25.0%5C""** (%5C to escape the ending quote). The library then runs this code over it :
**arr[1].replace(/\"{2,}/g, '"').replace(/(^")|("$)/g, '')**

This creates the following string : **"25.0\"**
The above does not have a trailing double quote and the value now ends with a backslash.

**Solution :**
Changing the order of the replace functions corrects this behaviour.
