### PR TITLE
Removed double quote escape character while parsing filters from url …

### DIFF
--- a/unbxdSearch.js
+++ b/unbxdSearch.js
@@ -1265,7 +1265,7 @@ var unbxdSearchInit = function(jQuery, Handlebars){
 	  for(var x = 0; x < filterStrArr.length; x++){
 	    var arr = filterStrArr[x].split(":");
 	    if(arr.length == 2){
-	      arr[1] = arr[1].replace(/(^")|("$)/g, '').replace(/\"{2,}/g, '"').replace(/(^\[)|(\]$)/g, '');
+	      arr[1] = arr[1].replace(/(^")|("$)/g, '').replace(/\"{2,}/g, '"').replace(/\\\"/g, '"').replace(/(^\[)|(\]$)/g, '');
 
 	      var vals = arr[1].split(" TO ");
 	      if(vals.length > 1){


### PR DESCRIPTION
…as escape is added again before calling search api

@santosh1994 @rahulcs Please review.

Escape char before double quotes is added before search API is fired. If you reload the same url, an extra escape character comes before the double quote before the search API is fired. Preventing this behaviour.