### PR TITLE
(feat): use 'format=json'

### DIFF
--- a/unbxdSearch.js
+++ b/unbxdSearch.js
@@ -1247,7 +1247,7 @@ var unbxdSearchInit = function(jQuery, Handlebars){
 	,sort : {}
 	,ranges : {}
 	,extra : {
-          wt : "json"
+          format : "json"
           ,page : 1
           ,rows : 12
 	}


### PR DESCRIPTION
since 'wt=json' is deprecated use 'format=json'