### PR TITLE
Custom jquery option

### DIFF
--- a/test/search/jqueryVersion.spec.js
+++ b/test/search/jqueryVersion.spec.js
@@ -1,0 +1,14 @@
+describe('jQuery version', function() {
+
+  it('jQuery version - check minimum jQuery version required', function() {
+    var validVersions = ['1.7.0', '1.11.1'];
+    var inValidVersions = ['1.4.0', '0.7.1'];
+    validVersions.forEach(function(version) {
+      expect(window.Unbxd.isJqueryRequiredVersion(version)).to.be.true;
+    });
+
+    inValidVersions.forEach(function(version) {
+      expect(window.Unbxd.isJqueryRequiredVersion(version)).to.be.false;
+    });
+  });
+});

--- a/unbxdSearch.js
+++ b/unbxdSearch.js
@@ -1981,12 +1981,31 @@ var unbxdSearchInit = function(jQuery, Handlebars){
   });
 };
 
-if(!window.jQuery || !window.Handlebars) 
-  throw "Please include jQuery & Handlebars libraries before loading unbxdSearch.js";
 
-var arr = jQuery.fn.jquery.split('.');
-if( arr[0] < 1 || (arr[0] == 1 && arr[1] < 7) ) 
-  throw "jQuery version needs to be greater than 1.7 to use unbxdSearch.js. You can pass custom jQuery & Handlebars by calling unbxdSeachInit(jQuery, Handlebars)";
+Unbxd = window.Unbxd || {};
 
+Unbxd.isJqueryRequiredVersion = Unbxd.isJqueryRequiredVersion ||
+  function isJqueryRequiredVersion(current) {
+    var jQueryVersion = current.split('.');
+    jQueryVersion = jQueryVersion.map(function convertToNumber(version) {
+      return Number(version);
+    });
+    if (
+      jQueryVersion[0] > 1 || (jQueryVersion[0] === 1 && jQueryVersion[1] >= 7)
+    ) {
+      return true;
+    }
+    return false;
+  };
 
-unbxdSearchInit(jQuery, Handlebars);
+if (!window.jQuery || !window.Handlebars) {
+  console.error(
+    'Please include jQuery & Handlebars libraries before loading unbxdSearch.js or You can pass custom jQuery & Handlebars by calling unbxdSeachInit(jQuery, Handlebars) '
+  );
+} else if (!Unbxd.isJqueryRequiredVersion(jQuery.fn.jquery)) {
+  console.error(
+    'jQuery version needs to be greater than 1.7 to use unbxdSearch.js. You can pass custom jQuery & Handlebars by calling unbxdSeachInit(jQuery, Handlebars)'
+  );
+} else {
+  unbxdSearchInit(jQuery, Handlebars);
+}

--- a/unbxdSearch.js
+++ b/unbxdSearch.js
@@ -1,7 +1,7 @@
 //uglifyjs unbxdSearch.js -o unbxdSearch.min.js && gzip -c unbxdSearch.min.js > unbxdSearch.min.js.gz && aws s3 cp unbxdSearch.min.js.gz s3://unbxd/unbxdSearch.js --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers --content-encoding gzip --cache-control max-age=3600
 var unbxdSearchInit = function(jQuery, Handlebars){
   window.Unbxd = window.Unbxd || {};
-  Unbxd.jsSdkVersion = "1.0.9";
+  Unbxd.jsSdkVersion = "1.0.10";
 
   // Production steps of ECMA-262, Edition 5, 15.4.4.14
   // Reference: http://es5.github.io/#x15.4.4.14


### PR DESCRIPTION
fixes #51 
@floydpraveen @rahulcs Please review

If jQuery or Handlebars not present or version not satisfied, then log the error and continue execution instead of throwing error. `unbxdSearchInit` can be later called when required jQuery and handlebars are loaded