### PR TITLE
deps: use jquery-ui v1.12.0 instead of v1.10.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "chai": "^3.5.0",
     "handlebars": "^4.0.5",
     "jquery": "1.9.1",
-    "jquery-ui": "1.10.4",
+    "jquery-ui": "1.12.0",
     "karma": "^1.3.0",
     "karma-chai": "^0.1.0",
     "karma-fixture": "^0.2.6",
@@ -41,7 +41,7 @@
     "karma-spec-reporter": "0.0.26",
     "karma-verbose-reporter": "0.0.3",
     "mocha": "^3.2.0",
-    "sinon": "^1.17.7",
-    "phantom": "^2.1.7"
+    "phantom": "^2.1.7",
+    "sinon": "^1.17.7"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1050,9 +1050,9 @@ isstream@0.1.x, isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
-jquery-ui@1.10.4:
-  version "1.10.4"
-  resolved "https://registry.yarnpkg.com/jquery-ui/-/jquery-ui-1.10.4.tgz#a096fe5f4e0f2ab69a0585cf10455877f57506bd"
+jquery-ui@1.12.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/jquery-ui/-/jquery-ui-1.12.0.tgz#59c6037a2d9c57e9a2521a9b7a497116d41b4246"
 
 jquery@1.9.1:
   version "1.9.1"


### PR DESCRIPTION
v1.10.4 has known moderate severity potential security vulnerability. this was warned by github on https://github.com/unbxd/js-sdk/network/dependencies#5995948. you can read more about it here: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-7103