### PR TITLE
chore(positioning):send position of facets to config

### DIFF
--- a/UnbxdSearch_IO.js
+++ b/UnbxdSearch_IO.js
@@ -2093,7 +2093,8 @@ var unbxdSearchInit = function (jQuery, Handlebars) {
                     selected: [],
                     unselected: [],
                     unordered: [],
-                    isMultilevel: (facets[x].hasOwnProperty("multiLevelField")) ? true : false
+                    isMultilevel: (facets[x].hasOwnProperty("multiLevelField")) ? true : false,
+                    position: facets[x].position || 999
                 };
                 // custom solution
                 if (singlefacet["facet_name"] == "categoryPath") {


### PR DESCRIPTION
Earlier, facets are grouped separately based on type and ordered within a group.
However, for v2, facets positioning should be respected in the UI across all groups.
Related PR:
https://github.com/unbxd/phoenix/pull/285/files?w=1